### PR TITLE
Bugfix/500 errors

### DIFF
--- a/lib/zendesk-uploader/client-wrapper.js
+++ b/lib/zendesk-uploader/client-wrapper.js
@@ -7,6 +7,7 @@ const logger = require('../logger');
  * Wrapper class for the `node-zendesk` api client
  * Wraps all requests in the `articles`, `sections`, `categories`, and `accesspolcies` objects in Promises
  * Also wraps requests with a retry functionality that will retry the request if the error response is >= 500 or contains a `retryAfter` property
+ * Subsequent retries without a "retry-after" header will wait twice as long as the last retry before trying the request again
  */
 
 const MAX_RETRIES = 5;
@@ -57,6 +58,7 @@ module.exports = class ZendeskClientWrapper {
 
     _createPromiseRequest() {
         let retries = MAX_RETRIES;
+        let retryNumber = 0;
         // First param is the method to call - subsequent params will be passed to the method
         const args = [].slice.call(arguments);
         const method = args.shift();
@@ -68,7 +70,11 @@ module.exports = class ZendeskClientWrapper {
                     // err.retryAfter is present on all 429 (rate limit has been exceeded) and some 503 errors
                     // err.retryAfter is time to wait in seconds
                     retries--;
-                    let retryAfter = err.retryAfter ? err.retryAfter * 1000 : RETRY_AFTER_DEFAULT;
+                    retryNumber++;
+                    const retryAfter = err.retryAfter
+                        ? err.retryAfter * 1000
+                        // Default retry should wait twice as long as the previous retry
+                        : RETRY_AFTER_DEFAULT * Math.max(Math.pow(2, retryNumber - 1), 1);
                     setTimeout(() => method.apply(this, args), retryAfter);
 
                     logger.warn(`Zendesk request failed. Retrying request after ${retryAfter} milliseconds. ${retries} attempts are remaining.`);

--- a/lib/zendesk-uploader/client-wrapper.js
+++ b/lib/zendesk-uploader/client-wrapper.js
@@ -1,18 +1,25 @@
-const request = require('request');
-const fs = require('fs');
+const Promise = require('bluebird');
 const Queue = require('promise-queue');
+
+const fs = require('fs');
+const request = require('request');
+
 const constants = require('./constants');
 const logger = require('../logger');
+
+Queue.configure(Promise);
 
 /**
  * Wrapper class for the `node-zendesk` api client
  * Wraps all requests in the `articles`, `sections`, `categories`, and `accesspolcies` objects in Promises
  * Also wraps requests with a retry functionality that will retry the request if the error response is >= 500 or contains a `retryAfter` property
  * Subsequent retries without a "retry-after" header will wait twice as long as the last retry before trying the request again
+ * Also contains a request queue to limit the number of concurrent connections
  */
 
-const MAX_RETRIES = 5;
+const MAX_RETRIES = 6;
 const RETRY_AFTER_DEFAULT = 500;
+const RETRY_AFTER_MAX = 8000;
 const MAX_CONCURRENT = 29;
 
 module.exports = class ZendeskClientWrapper {
@@ -31,11 +38,15 @@ module.exports = class ZendeskClientWrapper {
             'categories',
             'translations'
         ];
+
         endpoints.forEach(endpoint => {
             this._wrapPrototypeMethods(endpoint);
         });
+
         // This method must be created manually because the API client doesn't have it
-        this.articleattachments.create = (articleId, resourcePath) => this._queue.add(() => this._createPromiseRequest(this._createAttachment, articleId, resourcePath));
+        this.articleattachments.create = (articleId, resourcePath) => {
+            return this._createPromiseRequest(this, this._createAttachment, articleId, resourcePath);
+        };
     }
 
     _wrapPrototypeMethods(property) {
@@ -55,37 +66,49 @@ module.exports = class ZendeskClientWrapper {
         property[method] = (...args) => {
             args = [client[method]].concat(args);
             // Passes the method's parent object as `this` value - for example `client.articles`
-            return this._queue.add(() => this._createPromiseRequest.apply(client, args));
+            args = [client].concat(args);
+            return this._createPromiseRequest(...args);
         };
     }
 
     _createPromiseRequest(...args) {
         let retries = MAX_RETRIES;
-        let retryNumber = 0;
-        // First param is the method to call - subsequent params will be passed to the method
+        // First param is `this` value - second is the method to call - subsequent params will be passed to the method
+        const client = args.shift();
         const method = args.shift();
-        return new Promise((resolve, reject) => {
+
+        const promise = () => new Promise((resolve, reject) => {
             args.push((err, statusCode, result) => {
                 if (!err) {
                     return resolve(result);
                 } else if ((err.retryAfter || err.statusCode >= 500) && retries > 0) {
                     // err.retryAfter is present on all 429 (rate limit has been exceeded) and some 503 errors
                     // err.retryAfter is time to wait in seconds
-                    retries--;
-                    retryNumber++;
                     const retryAfter = err.retryAfter
                         ? err.retryAfter * 1000
-                        // Default retry should wait twice as long as the previous retry
-                        : RETRY_AFTER_DEFAULT * Math.max(Math.pow(2, retryNumber - 1), 1);
-                    setTimeout(() => method.apply(this, args), retryAfter);
+                        : this._calcRetryAfter(MAX_RETRIES - retries);
+                    retries--;
+                    setTimeout(() => method.apply(client, args), retryAfter);
 
                     logger.warn(`Zendesk request failed. Retrying request after ${retryAfter} milliseconds. ${retries} attempts are remaining.`);
                 } else {
                     return reject(err);
                 }
             });
-            method.apply(this, args);
+            method.apply(client, args);
         });
+
+        return this._queue.add(promise);
+    }
+
+    _calcRetryAfter(retryNumber) {
+        // Default retry should wait twice as long as the previous retry
+        const multiplier = Math.max(Math.pow(2, retryNumber), 1);
+
+        return Math.min(
+            RETRY_AFTER_DEFAULT * multiplier,
+            RETRY_AFTER_MAX
+        );
     }
 
     _createAttachment(articleId, resourcePath, callback) {

--- a/lib/zendesk-uploader/client-wrapper.js
+++ b/lib/zendesk-uploader/client-wrapper.js
@@ -1,5 +1,6 @@
 const request = require('request');
 const fs = require('fs');
+const Queue = require('promise-queue');
 const constants = require('./constants');
 const logger = require('../logger');
 
@@ -12,6 +13,7 @@ const logger = require('../logger');
 
 const MAX_RETRIES = 5;
 const RETRY_AFTER_DEFAULT = 500;
+const MAX_CONCURRENT = 29;
 
 module.exports = class ZendeskClientWrapper {
     /**
@@ -20,6 +22,7 @@ module.exports = class ZendeskClientWrapper {
      */
     constructor(client) {
         this._client = client;
+        this._queue = new Queue(MAX_CONCURRENT);
         const endpoints = [
             'articles',
             'articleattachments',
@@ -32,7 +35,7 @@ module.exports = class ZendeskClientWrapper {
             this._wrapPrototypeMethods(endpoint);
         });
         // This method must be created manually because the API client doesn't have it
-        this.articleattachments.create = (articleId, resourcePath) => this._createPromiseRequest(this._createAttachment, articleId, resourcePath);
+        this.articleattachments.create = (articleId, resourcePath) => this._queue.add(() => this._createPromiseRequest(this._createAttachment, articleId, resourcePath));
     }
 
     _wrapPrototypeMethods(property) {
@@ -52,15 +55,14 @@ module.exports = class ZendeskClientWrapper {
         property[method] = (...args) => {
             args = [client[method]].concat(args);
             // Passes the method's parent object as `this` value - for example `client.articles`
-            return this._createPromiseRequest.apply(client, args);
+            return this._queue.add(() => this._createPromiseRequest.apply(client, args));
         };
     }
 
-    _createPromiseRequest() {
+    _createPromiseRequest(...args) {
         let retries = MAX_RETRIES;
         let retryNumber = 0;
         // First param is the method to call - subsequent params will be passed to the method
-        const args = [].slice.call(arguments);
         const method = args.shift();
         return new Promise((resolve, reject) => {
             args.push((err, statusCode, result) => {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "markdown-it": "8.3.1",
     "markdown-it-github-toc": "3.1.0",
     "node-zendesk": "1.1.12",
-    "promise-queue": "^2.2.3"
+    "promise-queue": "2.2.3"
   },
   "devDependencies": {
     "chai": "3.5.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "lodash": "4.17.4",
     "markdown-it": "8.3.1",
     "markdown-it-github-toc": "3.1.0",
-    "node-zendesk": "1.1.12"
+    "node-zendesk": "1.1.12",
+    "promise-queue": "^2.2.3"
   },
   "devDependencies": {
     "chai": "3.5.0",

--- a/test/unit/zendesk-uploader/client-wrapper.js
+++ b/test/unit/zendesk-uploader/client-wrapper.js
@@ -188,6 +188,17 @@ describe('ZendeskClientWrapper', () => {
                         .to.have.been.calledWithMatch(/10 milliseconds/);
                 });
         });
+
+        it('should not allow more than 29 concurrent connections', () => {
+            let connections = 0;
+            sandbox.stub(this.zendeskStub.articles, 'create', () => connections++);
+
+            for (let i = 0; i < 30; i++) {
+                this.zendeskClient.articles.create(123, {test: 'test'});
+            }
+
+            expect(connections).to.be.equal(29);
+        });
     });
 
     describe('articleattachments.create', () => {

--- a/test/unit/zendesk-uploader/client-wrapper.js
+++ b/test/unit/zendesk-uploader/client-wrapper.js
@@ -153,7 +153,13 @@ describe('ZendeskClientWrapper', () => {
             let clock = sandbox.useFakeTimers();
             let createArticle = this.zendeskClient.articles.create(123, {});
 
-            clock.tick(500 + 1000 + 2000);
+            clock.tick(500);
+            expect(stub).to.be.calledTwice;
+
+            clock.tick(1000);
+            expect(stub).to.be.calledThrice;
+
+            clock.tick(2000);
             return createArticle.then(() => {
                 expect(stub.callCount).to.be.equal(4);
             });
@@ -166,7 +172,10 @@ describe('ZendeskClientWrapper', () => {
             let clock = sandbox.useFakeTimers();
             let createArticle = this.zendeskClient.articles.create(123, {});
 
-            clock.tick(500 + 1000 + 2000 + 4000 + 8000 + 8000);
+            clock.tick(500 + 1000 + 2000 + 4000 + 8000);
+            expect(stub.callCount).to.be.equal(6);
+
+            clock.tick(8000);
             return createArticle.then(() => {
                 expect(stub.callCount).to.be.equal(7);
             });

--- a/test/unit/zendesk-uploader/client-wrapper.js
+++ b/test/unit/zendesk-uploader/client-wrapper.js
@@ -148,7 +148,7 @@ describe('ZendeskClientWrapper', () => {
 
         it('should retry after twice as long as the last retry for the request when there are subsequent 500 errors', () => {
             const stub = sandbox.stub(this.zendeskStub.articles, 'create').yields({statusCode: 503});
-            stub.onCall(3).yields(null, null, {});
+            stub.onCall(2).yields(null, null, {});
 
             let clock = sandbox.useFakeTimers();
             let createArticle = this.zendeskClient.articles.create(123, {});
@@ -156,12 +156,12 @@ describe('ZendeskClientWrapper', () => {
             clock.tick(500);
             expect(stub).to.be.calledTwice;
 
-            clock.tick(1000);
-            expect(stub).to.be.calledThrice;
+            clock.tick(500);
+            expect(stub).to.be.calledTwice;
 
-            clock.tick(2000);
+            clock.tick(500);
             return createArticle.then(() => {
-                expect(stub.callCount).to.be.equal(4);
+                expect(stub).to.be.calledThrice;
             });
         });
 


### PR DESCRIPTION
Resolves #13 

Added incremental retries - each retry will take twice as long as the previous retry.

Added a queue using the "promise-request" module so that no more than 29 connections can be made at once. This has reduced the number of request retries caused by 500 errors.